### PR TITLE
hashbang now points to user's current python environment

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 # For best results use source code pro
 # Arrows
@@ -7,7 +7,7 @@
 import datetime
 import random
 import getpass
-#Stupid windows
+#Stupid windows # <- I agree...
 try:
     import msvcrt
 except ImportError:


### PR DESCRIPTION
Originally the hashbang forced the use of the system python.  It is better to call whichever python the user has active in order to ensure correct dependency handeling.